### PR TITLE
修复showdoc 3.0+ 兼容性错误

### DIFF
--- a/internal/single_catalog_generator.go
+++ b/internal/single_catalog_generator.go
@@ -3,10 +3,11 @@ package internal
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/ruapi-generate-md/pkg"
-	"github.com/ruapi-generate-md/pkg/tools"
 	"os"
 	"strings"
+
+	"github.com/ruapi-generate-md/pkg"
+	"github.com/ruapi-generate-md/pkg/tools"
 )
 
 func codeAreaWrite(sb *strings.Builder, codeArea string) {
@@ -115,7 +116,9 @@ func generateOnePageMarkDown(jsonStr string, globalHeader []pkg.Header, bigTile 
 	data := pkg.PageContent{}
 	err := json.Unmarshal([]byte(jsonStr), &data)
 	if err != nil {
-		panic(err)
+		fmt.Println("无法解析页面内容:", jsonStr)
+		fmt.Println(err)
+		return
 	}
 	var sb strings.Builder
 	sb.WriteString("<!-- 使用表格样式 -->\n" +

--- a/pkg/show_doc_struct.go
+++ b/pkg/show_doc_struct.go
@@ -68,7 +68,7 @@ type PageContent struct {
 		Pre  string `json:"pre"`
 		Post string `json:"post"`
 	} `json:"scripts"`
-	Extend struct {
+	Extend interface {
 	} `json:"extend"`
 }
 type Header struct {


### PR DESCRIPTION
showdoc 版本 v3.2.2

1、针对 markdown 页面无法解析时跳过，并打印提示信息

2、PageContent.Extend 为数组时无法解析